### PR TITLE
Initialize Q++ skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# qq
+# Q++ App
+
+This repository contains a minimal MVP implementation of the Q++ transformation platform. It consists of a React (Vite + Tailwind) frontend and a Flask backend.
+
+## Frontend
+- Located in `frontend/`
+- Run `npm install` then `npm run dev` to start development server.
+
+## Backend
+- Located in `backend/`
+- Install dependencies: `pip install flask flask_sqlalchemy flask_cors werkzeug`
+- Run `python app.py` to start the API server.
+
+This code serves as a starting point to build the full Q++ system.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,73 @@
+from flask import Flask, request, jsonify
+from flask_sqlalchemy import SQLAlchemy
+from flask_cors import CORS
+from werkzeug.security import generate_password_hash, check_password_hash
+from config.db import db, User, Profile, Referral
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///qplusplus.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SECRET_KEY'] = 'changeme'
+CORS(app)
+
+db.init_app(app)
+
+@app.before_first_request
+def create_tables():
+    db.create_all()
+
+@app.route('/api/register', methods=['POST'])
+def register():
+    data = request.json
+    if User.query.filter_by(email=data['email']).first():
+        return jsonify({'message': 'User exists'}), 400
+    hashed = generate_password_hash(data['password'])
+    user = User(email=data['email'], password=hashed)
+    db.session.add(user)
+    db.session.commit()
+    profile = Profile(user_id=user.id)
+    db.session.add(profile)
+    db.session.commit()
+    return jsonify({'message': 'Registered'})
+
+@app.route('/api/login', methods=['POST'])
+def login():
+    data = request.json
+    user = User.query.filter_by(email=data['email']).first()
+    if user and check_password_hash(user.password, data['password']):
+        return jsonify({'message': 'Logged in', 'user_id': user.id})
+    return jsonify({'message': 'Invalid credentials'}), 401
+
+@app.route('/api/profile/<int:user_id>', methods=['GET'])
+def get_profile(user_id):
+    profile = Profile.query.filter_by(user_id=user_id).first()
+    if not profile:
+        return jsonify({'message': 'Profile not found'}), 404
+    return jsonify({'iq': profile.iq, 'eq': profile.eq, 'aq': profile.aq})
+
+@app.route('/api/chat', methods=['POST'])
+def chat():
+    data = request.json
+    user_message = data.get('message')
+    # Placeholder GPT response
+    gpt_response = f"GPT-4o would respond to: {user_message}"
+    return jsonify({'response': gpt_response})
+
+@app.route('/api/referral', methods=['POST'])
+def referral():
+    data = request.json
+    ref = Referral(referrer_email=data['referrer'], referred_email=data['referred'])
+    db.session.add(ref)
+    db.session.commit()
+    return jsonify({'message': 'Referral recorded'})
+
+@app.route('/api/pay', methods=['POST'])
+def pay():
+    data = request.json
+    ref = Referral.query.filter_by(referred_email=data['email']).first()
+    if ref:
+        ref.paid = True
+    return jsonify({'message': 'Payment processed (placeholder)'})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/config/db.py
+++ b/config/db.py
@@ -1,0 +1,32 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# Database instance
+
+db = SQLAlchemy()
+
+# User model
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password = db.Column(db.String(128), nullable=False)
+    referrals = db.relationship('Referral', backref='user', lazy=True)
+    profile = db.relationship('Profile', backref='user', uselist=False)
+
+class Profile(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    iq = db.Column(db.Integer, default=0)
+    eq = db.Column(db.Integer, default=0)
+    aq = db.Column(db.Integer, default=0)
+
+class QPlusPlusScore(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    score_type = db.Column(db.String(10))
+    value = db.Column(db.Integer)
+
+class Referral(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    referrer_email = db.Column(db.String(120))
+    referred_email = db.Column(db.String(120))
+    paid = db.Column(db.Boolean, default=False)

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Q++ App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "qplusplus-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.3.0"
+  }
+}

--- a/frontend/pages/AudioPage.jsx
+++ b/frontend/pages/AudioPage.jsx
@@ -1,0 +1,7 @@
+export default function AudioPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Audio Anchors</h1>
+    </div>
+  );
+}

--- a/frontend/pages/ChatPage.jsx
+++ b/frontend/pages/ChatPage.jsx
@@ -1,0 +1,7 @@
+export default function ChatPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">GPT Chat</h1>
+    </div>
+  );
+}

--- a/frontend/pages/DashboardPage.jsx
+++ b/frontend/pages/DashboardPage.jsx
@@ -1,0 +1,7 @@
+export default function DashboardPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Dashboard</h1>
+    </div>
+  );
+}

--- a/frontend/pages/ForumPage.jsx
+++ b/frontend/pages/ForumPage.jsx
@@ -1,0 +1,7 @@
+export default function ForumPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Community Forum</h1>
+    </div>
+  );
+}

--- a/frontend/pages/HomePage.jsx
+++ b/frontend/pages/HomePage.jsx
@@ -1,0 +1,7 @@
+export default function HomePage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Welcome to Q++</h1>
+    </div>
+  );
+}

--- a/frontend/pages/LoginPage.jsx
+++ b/frontend/pages/LoginPage.jsx
@@ -1,0 +1,7 @@
+export default function LoginPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Login</h1>
+    </div>
+  );
+}

--- a/frontend/pages/ProfilePage.jsx
+++ b/frontend/pages/ProfilePage.jsx
@@ -1,0 +1,7 @@
+export default function ProfilePage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Your Profile</h1>
+    </div>
+  );
+}

--- a/frontend/pages/RegisterPage.jsx
+++ b/frontend/pages/RegisterPage.jsx
@@ -1,0 +1,7 @@
+export default function RegisterPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Register</h1>
+    </div>
+  );
+}

--- a/frontend/pages/TestPage.jsx
+++ b/frontend/pages/TestPage.jsx
@@ -1,0 +1,7 @@
+export default function TestPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Q++ Test</h1>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import HomePage from '../pages/HomePage';
+import RegisterPage from '../pages/RegisterPage';
+import LoginPage from '../pages/LoginPage';
+import DashboardPage from '../pages/DashboardPage';
+import TestPage from '../pages/TestPage';
+import ChatPage from '../pages/ChatPage';
+import AudioPage from '../pages/AudioPage';
+import ForumPage from '../pages/ForumPage';
+import ProfilePage from '../pages/ProfilePage';
+import '../index.css';
+
+const App = () => (
+  <Router>
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/dashboard" element={<DashboardPage />} />
+      <Route path="/test" element={<TestPage />} />
+      <Route path="/chat" element={<ChatPage />} />
+      <Route path="/audio" element={<AudioPage />} />
+      <Route path="/forum" element={<ForumPage />} />
+      <Route path="/profile" element={<ProfilePage />} />
+    </Routes>
+  </Router>
+);
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}',
+    './pages/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
## Summary
- create minimal React frontend with Vite and Tailwind
- add placeholder pages
- add Flask backend with basic auth, GPT chat placeholder and referral endpoints
- define SQLAlchemy models for users, profiles, Q++ scores and referrals
- update README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683c7152fa688327b7916f573363e8a9